### PR TITLE
Extend-request-for-logging

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import { TypeOrmModule } from '@nestjs/typeorm/dist';
@@ -8,6 +8,7 @@ import { TypeOrmConfigService } from './common/config/typeorm-config.service';
 import { AllExceptionFilter } from './common/filters/all-exception.filter';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { WinstonLoggerModule } from './common/logger/winston-logger.module';
+import { ExtendRequest } from './common/middlewares/extend-request.middleware';
 import { CatsModule } from './modules/cats/cats.module';
 
 @Module({
@@ -26,4 +27,8 @@ import { CatsModule } from './modules/cats/cats.module';
   ],
   controllers: [AppController],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(ExtendRequest).forRoutes('*');
+  }
+}

--- a/src/common/logger/extended-request.ts
+++ b/src/common/logger/extended-request.ts
@@ -1,0 +1,34 @@
+import { Request } from 'express';
+
+export interface ExtendedRequest extends Request {
+  extra: Extra;
+}
+
+export class Extra {
+  private startTime: Date;
+  private endTime: Date;
+  private executionTime: number;
+
+  constructor() {
+    this.startTime = new Date();
+    this.endTime = null;
+    this.executionTime = null;
+  }
+
+  getStartTime(): Date {
+    return this.startTime;
+  }
+  getEndTime(): Date {
+    return this.endTime;
+  }
+  setEndTime() {
+    this.endTime = new Date();
+  }
+  getExecutionTime(): number {
+    return this.executionTime;
+  }
+  setExecutionTime() {
+    this.setEndTime();
+    this.executionTime = this.endTime.getMilliseconds() - this.startTime.getMilliseconds();
+  }
+}

--- a/src/common/logger/winston-logger.serivce.ts
+++ b/src/common/logger/winston-logger.serivce.ts
@@ -1,9 +1,11 @@
 import { Injectable, LoggerService } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Response } from 'express';
 import { Env } from 'src/app.constant';
 import * as winston from 'winston';
 import { Logger } from 'winston';
 import 'winston-daily-rotate-file';
+import { ExtendedRequest } from './extended-request';
 
 /**
  * @summary Nest.js의 LoggerService를 구현하는 winston logger입니다.
@@ -84,5 +86,16 @@ export class WinstonLogger implements LoggerService {
   }
   warn(message: any) {
     this.errorLogger.warn(message);
+  }
+
+  createLoggingObject(request: ExtendedRequest, response: Response) {
+    return {
+      method: request.method,
+      url: request.url,
+      statusCode: response.statusCode,
+      startTime: request.extra.getStartTime(),
+      endTime: request.extra.getEndTime(),
+      executionTime: `${request.extra.getExecutionTime()}ms`,
+    };
   }
 }

--- a/src/common/middlewares/extend-request.middleware.ts
+++ b/src/common/middlewares/extend-request.middleware.ts
@@ -1,0 +1,11 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Response } from 'express';
+import { ExtendedRequest, Extra } from '../logger/extended-request';
+
+@Injectable()
+export class ExtendRequest implements NestMiddleware {
+  use(req: ExtendedRequest, res: Response, next: (error?: any) => void) {
+    req.extra = new Extra();
+    next();
+  }
+}


### PR DESCRIPTION
- AllExceptionFilter와 LoggingInterceptor에서 동일한 로깅 메시지 형식을 가질 수 있도록 하기 위해서 Request 객체를 확장한 ExtendedRequest를 추가하고 적용했다.